### PR TITLE
Basic setup for Scapy-like custom ethernet

### DIFF
--- a/CustomEth/include/io.h
+++ b/CustomEth/include/io.h
@@ -1,0 +1,2 @@
+// Add raw socket sending function
+

--- a/CustomEth/include/layers.h
+++ b/CustomEth/include/layers.h
@@ -1,0 +1,171 @@
+#pragma once
+#include <array>
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include "util/checksum.h"
+
+enum class Kind {
+  DEFAULT,
+  ETHER, 
+  IPV4, 
+  UDP,
+  TCP,
+  ICMP,
+  IPV6
+};
+
+struct Layer {
+  virtual ~Layer() = default;
+  virtual Kind kind() {
+    return Kind::DEFAULT;
+  }
+  virtual int get_header_length() {
+    return 0;
+  }
+  virtual int get_physical_length() {
+    return 0;
+  }
+  virtual void update_len(int len) {}
+  virtual void update_checksum() {}
+};
+
+struct ether: Layer {
+    uint16_t ethertype{0x0800};
+    std::array<uint8_t, 6> src{}, dst{};
+
+    void set_src_ether (const std::string& src_mac) {
+        std::istringstream data(src_mac);
+        std::string line;
+        int index = 0;
+        while(std::getline(data,line,':')) {
+            uint8_t temp = std::stoi(line, nullptr, 16);
+            src[index] = static_cast<uint8_t>(temp);
+            index++;
+        }
+    }
+
+    void set_dst_ether (const std::string& dst_mac) {
+        std::istringstream data(dst_mac);
+        std::string line;
+        int index = 0;
+        while(std::getline(data,line,':')) {
+            uint8_t temp = std::stoi(line, nullptr, 16);
+            dst[index] = static_cast<uint8_t>(temp);
+            index++;
+        }
+    }
+
+    Kind kind() override {
+        return Kind::ETHER;
+    }
+
+    int get_header_length() override {
+        return 14;
+    }
+
+    int get_physical_length() override {
+        return 14;
+    }
+};
+
+struct ipv4: Layer {
+    uint8_t ihl = 5;
+    uint8_t tos = 0;
+    uint16_t total_len = 0;
+    uint16_t id = 0;
+    uint16_t flag_fragment = 0;
+    uint8_t  ttl = 64, proto = 17;
+    uint16_t checksum = 0;
+    std::array<uint8_t, 4> src{}, dst{};
+
+    uint16_t len_after_ip_header = 0;
+
+    Kind kind() override {
+        return Kind::IPV4;
+    }
+
+    void set_dst_ipv4 (const std::string& dst_ip) {
+        std::istringstream data(dst_ip);
+        std::string line;
+        int index = 0;
+        while(std::getline(data,line,':')) {
+            uint8_t temp = std::stoi(line, nullptr, 16);
+            dst[index] = static_cast<uint8_t>(temp);
+            index++;
+        }
+    }
+
+    void set_src_ipv4 (const std::string& src_ip) {
+        std::istringstream data(src_ip);
+        std::string line;
+        int index = 0;
+        while(std::getline(data,line,':')) {
+            uint8_t temp = std::stoi(line, nullptr, 16);
+            src[index] = static_cast<uint8_t>(temp);
+            index++;
+        }
+    }
+
+    int get_header_length () override {
+        return 20;
+    }
+
+    int get_physical_length() override {
+        return 20;
+    }
+};
+
+struct udp: Layer {
+    uint16_t sport = 0;
+    uint16_t dport = 0;
+    uint16_t checksum = 0;
+    uint16_t len = 8;
+    std::vector<uint8_t> payload;
+
+    void set_source_port(const std::string& s_port) {
+        sport = static_cast<uint16_t>(std::stoi(s_port));
+    }
+
+    void set_dest_port(const std::string& d_port) {
+        dport = static_cast<uint16_t>(std::stoi(d_port));
+    }
+
+    Kind kind() override {
+        return Kind::UDP;
+    }
+
+    int get_header_length () override {
+        return 8;
+    }
+    int get_physical_length() override {
+        return static_cast<uint16_t>(8 + payload.size());
+    }
+};
+
+
+struct tcp: Layer {
+    uint16_t sport = 0;
+    uint16_t dport = 0;
+    uint32_t seq = 0;
+    uint32_t ack = 0;
+    uint8_t  data_offset = 5;
+    uint8_t flags = 0;
+    uint16_t window = 65535;
+    uint16_t checksum = 0;
+    uint16_t urgent_ptr = 0;
+    std::vector<uint8_t> options;
+    std::vector<uint8_t> payload;
+
+    Kind kind() override {
+        return Kind::TCP;
+    }
+
+    int get_header_length () override {
+        return static_cast<uint16_t>(4 * data_offset);
+    }
+
+    int get_physical_length() override {
+        return static_cast<uint16_t>(get_header_length() + payload.size());
+    }
+};

--- a/CustomEth/include/packet.h
+++ b/CustomEth/include/packet.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <vector>
+#include <memory>
+#include "layers.h"
+
+struct Packet {
+  std::vector<std::unique_ptr<Layer>> layers;
+  template <class L> Packet& push(const L& l) {
+    layers.push_back(std::make_unique<L>(l));
+    return *this;
+  }
+  void update();
+};
+
+template<class P, class Q>
+Packet operator/(const P& p, const Q& q) {
+  Packet pac;
+  pac.push(p);
+  pac.push(q);
+  return pac;
+}
+
+template<class P>
+Packet operator/(Packet&& pac, const P& p) {
+  pac.push(p);
+  return std::move(pac);
+}

--- a/CustomEth/include/util/checksum.h
+++ b/CustomEth/include/util/checksum.h
@@ -1,0 +1,6 @@
+#include <cstdint>
+#include <vector>
+
+uint16_t ipv4_checksum(uint16_t* header);
+
+uint16_t udp_checksum_helper(uint16_t* pseudo_header, uint16_t* udp_header, const std::vector<uint8_t>& payload);

--- a/CustomEth/src/packet.cpp
+++ b/CustomEth/src/packet.cpp
@@ -1,0 +1,68 @@
+#include "../include/packet.h"
+
+void Packet::update() {
+    for (auto &layer : layers) {
+        layer->update_checksum();
+    }
+
+    for (int i = 0; i < layers.size(); i++) {
+        if (layers[i]->kind() != Kind::IPV4) {
+            continue;
+        }
+
+        uint32_t len = 0;
+        for (int j = i + 1; j < layers.size(); j++) {
+            len += layers[j]->get_physical_length();
+        }
+
+        auto* ipv4_layer = static_cast<ipv4*>(layers[i].get());
+        uint16_t total_len = len + (4 * static_cast<uint16_t> (ipv4_layer->ihl));
+        uint16_t calc_checksum[10];
+
+        calc_checksum[0] = (4 << 12) | (ipv4_layer->ihl & 0xF) << 8 | (ipv4_layer->tos & 0xFF);
+        calc_checksum[1] = total_len;
+        calc_checksum[2] = ipv4_layer->id;
+        calc_checksum[3] = ipv4_layer->flag_fragment;
+        calc_checksum[4] = (ipv4_layer->ttl << 8) | ipv4_layer->proto;
+        calc_checksum[5] = 0x0000;
+        calc_checksum[6] = (ipv4_layer->src[0] << 8) | ipv4_layer->src[1];
+        calc_checksum[7] = (ipv4_layer->src[2] << 8) | ipv4_layer->src[3];
+        calc_checksum[8] = (ipv4_layer->dst[0] << 8) | ipv4_layer->dst[1];
+        calc_checksum[9] = (ipv4_layer->dst[2] << 8) | ipv4_layer->dst[3];
+
+        ipv4_layer->checksum = ipv4_checksum(calc_checksum);
+    }
+
+    for (int i = 0; i < layers.size(); i++) {
+        if (layers[i]->kind() != Kind::IPV4) {
+            continue;
+        }
+
+        if (layers[i+1]->kind() == Kind::UDP) {
+            uint16_t pseudo_header[6];
+            uint16_t udp_header[4];
+            auto* udp_layer = static_cast<udp*>(layers[i+1].get());
+            auto* ipv4_layer = static_cast<ipv4*>(layers[i].get());
+            pseudo_header[0] = (ipv4_layer->src[0] << 8) | ipv4_layer->src[1];
+            pseudo_header[1] = (ipv4_layer->src[2] << 8) | ipv4_layer->src[3];
+            pseudo_header[2] = (ipv4_layer->dst[0] << 8) | ipv4_layer->dst[1];
+            pseudo_header[3] = (ipv4_layer->dst[2] << 8) | ipv4_layer->dst[3];
+            pseudo_header[4] = (0x00 << 8) | (uint16_t) 17;
+            pseudo_header[5] = static_cast<uint16_t>(8 + udp_layer->payload.size());
+
+            udp_header[0] = udp_layer->sport;
+            udp_header[1] = udp_layer->dport;
+            udp_header[2] = static_cast<uint16_t>(8 + udp_layer->payload.size());
+            udp_header[3] = 0x0000;
+
+            udp_layer->checksum = udp_checksum_helper(pseudo_header, udp_header, udp_layer->payload);
+        }
+        if (layers[i+1]->kind() == Kind::TCP) {
+            auto* tcp_layer = static_cast<tcp*>(layers[i+1].get());
+            // Similarly do a TCP checksum calculation and update
+        }
+        if (layers[i+1]->kind() == Kind::ICMP) {
+        
+        }
+    }
+}

--- a/CustomEth/src/test.cpp
+++ b/CustomEth/src/test.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <memory>
+#include <vector>
+#include "../include/packet.h"
+
+int main() {
+    ether test1;
+    test1.set_src_ether("aa:aa:aa:aa:aa:aa");
+    test1.set_dst_ether("aa:aa:ab:aa:aa:aa");
+
+    ipv4 test2;
+    test2.set_src_ipv4("127.0.0.1");
+    test2.set_dst_ipv4("127.1.1.1");
+
+    udp test3;
+    test3.set_source_port("127");
+    test3.set_dest_port("128");
+    test3.payload.push_back(0xF);
+
+    Packet p;
+    p = test1 / test2 / test3;
+    p.update();
+}
+
+
+/*
+1. Add test functions to cross-check the actual bytes generated 
+2. Right now can handle UDP or TCP or ICMP ONLY (with the ether and IPv4 layers) - Need to add a stack up layered sender ? just needs different handling at the packet level 
+3. Add UA Link packet layers just like the current implemented ones 
+*/

--- a/CustomEth/util/checksum.cpp
+++ b/CustomEth/util/checksum.cpp
@@ -1,0 +1,44 @@
+#include "../include/util/checksum.h"
+
+uint16_t ipv4_checksum(uint16_t* header) {
+    uint32_t sum = 0;
+    uint16_t* temp = header;
+
+    for (int i = 0; i < 10; i++) {
+        sum += *temp++;
+    }
+
+    sum = (sum & 0xFFFF) + (sum >> 16);
+
+    return static_cast<uint16_t>(~sum);
+}
+
+uint16_t udp_checksum_helper(uint16_t* pseudo_header, uint16_t* udp_header, const std::vector<uint8_t>& payload) {
+    uint32_t sum_pseudo_header = 0;
+    uint16_t* temp_p_header = pseudo_header;
+    for (int i = 0; i < 6; i++) {
+        sum_pseudo_header += *temp_p_header++;
+    }
+    uint32_t sum_udp_header = 0;
+    uint16_t* temp_u_header = udp_header;
+    for (int i = 0; i < 4; i++) {
+        sum_udp_header += *temp_u_header++;
+    }
+    uint32_t sum_payload = 0;
+    int i = payload.size()-1;
+    while (i >= 1) {
+        sum_payload += (payload[i-1] << 8) | payload[i];
+        i = i - 2;
+    }
+
+    if (i > 0) {
+        sum_payload += payload[i] << 8;
+    }
+
+    uint32_t sum = sum_pseudo_header + sum_udp_header + sum_payload;
+
+    while (sum >> 16) {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+    return uint16_t(~sum);
+}


### PR DESCRIPTION
- Supports Scapy like packet generation for Ether/IPv4/UDP/TCP right now
- Supports packet layering
- Supports checksum generation for IPv4 and UDP 


Next TODOs

- Add raw socket function
- Add basic unit tests 
- Add UALink layer - some commands to start with - layer it like UDP or TCP 

Right now just compiling it with `g++ src/test.cpp src/packet.cpp util/checksum.cpp` - will add some formal methods 