### PR TITLE
Change ether type to 0x88B5

### DIFF
--- a/CustomEth/include/layers.h
+++ b/CustomEth/include/layers.h
@@ -32,7 +32,7 @@ struct Layer {
 };
 
 struct ether: Layer {
-    uint16_t ethertype{0x0800};
+    uint16_t ethertype{0x88B5};
     std::array<uint8_t, 6> src{}, dst{};
 
     void set_src_ether (const std::string& src_mac) {


### PR DESCRIPTION
- On some NICs the 0x0800 doesn't get accepted if the bytes following the ether are bogus
- and indeed we are using custom frame fully - so changing it to this type bypasses the checks
